### PR TITLE
feat(backend): add initial mongoose schemas and error middleware

### DIFF
--- a/backend/middlewares/errorHandlerMiddleware.js
+++ b/backend/middlewares/errorHandlerMiddleware.js
@@ -1,0 +1,11 @@
+const AppError = require("../utils/AppError");
+
+const errorHandler = (err, req, res, next) => {
+  const statusCode = err.statusCode || 500;
+  res.status(statusCode).json({
+    status: err.status || "error",
+    message: err.message || "Internal Server Error",
+  });
+};
+
+module.exports = errorHandler;

--- a/backend/models/artisanModel.js
+++ b/backend/models/artisanModel.js
@@ -1,0 +1,13 @@
+const mongoose = require("mongoose");
+
+const artisanSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true, lowercase: true },
+  passwordHash: { type: String, required: true },
+  bio: String,
+  isVerified: { type: Boolean, default: false },
+  documents: [String],
+  products: [{ type: mongoose.Schema.Types.ObjectId, ref: "Product" }],
+}, { timestamps: true });
+
+module.exports = mongoose.model("Artisan", artisanSchema);

--- a/backend/models/orderModel.js
+++ b/backend/models/orderModel.js
@@ -1,0 +1,18 @@
+const mongoose = require("mongoose");
+
+const orderSchema = new mongoose.Schema({
+  customer: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+  items: [
+    {
+      product: { type: mongoose.Schema.Types.ObjectId, ref: "Product" },
+      quantity: Number,
+      priceAtPurchase: Number,
+    }
+  ],
+  totalAmount: Number,
+  shippingAddress: String,
+  paymentStatus: { type: String, enum: ["Pending", "Paid", "Failed"], default: "Pending" },
+  orderStatus: { type: String, enum: ["Processing", "Shipped", "Delivered", "Cancelled"], default: "Processing" },
+}, { timestamps: true });
+
+module.exports = mongoose.model("Order", orderSchema);

--- a/backend/models/productModel.js
+++ b/backend/models/productModel.js
@@ -1,0 +1,15 @@
+const mongoose = require("mongoose");
+
+const productSchema = new mongoose.Schema({
+  artisan: { type: mongoose.Schema.Types.ObjectId, ref: "Artisan", required: true },
+  name: { type: String, required: true },
+  description: String,
+  price: { type: Number, required: true },
+  stock: { type: Number, default: 1 },
+  category: { type: String },
+  tags: [String],
+  images: [String],
+  isApproved: { type: Boolean, default: false },
+}, { timestamps: true });
+
+module.exports = mongoose.model("Product", productSchema);

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -1,0 +1,11 @@
+const mongoose = require("mongoose");
+
+const userSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true, lowercase: true },
+  passwordHash: { type: String, required: true },
+  address: { type: String },
+  role: { type: String, enum: ["user", "admin"], default: "user" },
+}, { timestamps: true });
+
+module.exports = mongoose.model("User", userSchema);

--- a/backend/utils/AppError.js
+++ b/backend/utils/AppError.js
@@ -1,0 +1,10 @@
+class AppError extends Error {
+  constructor(message, statusCode) {
+    super(message);
+    this.statusCode = statusCode || 500;
+    this.status = `${statusCode}`.startsWith("4") ? "fail" : "error";
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = AppError;


### PR DESCRIPTION
Hi Team,

This PR establishes the core data structures for our application and sets up our centralized error handling, as per our initial project plan.

**Changes Included:**

1.  **Mongoose Schemas:**
    * `models/userModel.js`
    * `models/artisanModel.js`
    * `models/productModel.js`
    * `models/orderModel.js`
2.  **Error Middleware:**
    * `middlewares/errorMiddleware.js`: A centralized middleware to catch errors and send a consistent JSON response, preventing the server from crashing