### PR TITLE
feat(backend): add deleteFromCloudinary utility

### DIFF
--- a/backend/utils/cloudinary.js
+++ b/backend/utils/cloudinary.js
@@ -25,4 +25,47 @@ const uploadOnCloudinary = async (localFilePath) => {
     }
 }
 
-export { uploadOnCloudinary };
+// Deletes a Cloudinary asset (image, video, raw) by parsing its public URL.
+const deleteFromCloudinary = async (fileUrl) => {
+    try {
+        if (!fileUrl) {
+            console.error("File URL is required to delete from Cloudinary");
+            return null;
+        }
+
+        // Extract the public_id from the URL.
+        const urlSegments = fileUrl.split('/');
+        const publicIdWithExtension = urlSegments[urlSegments.length - 1];
+        const publicId = publicIdWithExtension.split('.')[0];
+
+        if (!publicId) {
+            console.log("Could not extract public_id from URL:", fileUrl);
+            return null;
+        }
+
+        // Dynamically determine the resource type from the URL
+        let resourceType = 'image'; // Default to 'image'
+        const uploadIndex = urlSegments.indexOf('upload');
+        if (uploadIndex > 0) {
+            const potentialType = urlSegments[uploadIndex - 1];
+            if (['image', 'video', 'raw'].includes(potentialType)) {
+                resourceType = potentialType;
+            }
+        }
+        
+        // Use the 'destroy' method to delete the asset by its public_id and determined resource_type
+        const result = await cloudinary.uploader.destroy(publicId, {
+            resource_type: resourceType
+        });
+        
+        console.log("Asset deletion result from Cloudinary:", result);
+        return result;
+
+    } catch (error) {
+        console.error("Error deleting asset from Cloudinary:", error);
+        // Don't throw an error that stops the parent process, just log it.
+        return null;
+    }
+};
+
+export { uploadOnCloudinary, deleteFromCloudinary };


### PR DESCRIPTION
Implements the `deleteFromCloudinary` function in the cloudinary utility file.

This function takes a public image URL, extracts the public_id, and uses the Cloudinary API to delete the corresponding asset. This is a crucial utility needed for updating or deleting resources (like products) that have associated images.